### PR TITLE
Avoid encoding urls if they are already encoded

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -35,11 +35,7 @@ def scrape_group(name, url)
 end
 
 def valid_uri(url, path)
-  begin
-    URI.join(url, path)
-  rescue URI::InvalidURIError
-    URI.join(url, URI.escape(path))
-  end
+  URI.join(url, URI.escape(URI.unescape(path)))
 end
 
 def scrape_person(url, name, group)

--- a/scraper.rb
+++ b/scraper.rb
@@ -34,12 +34,20 @@ def scrape_group(name, url)
   end
 end
 
+def valid_uri(url, path)
+  begin
+    URI.join(url, path)
+  rescue URI::InvalidURIError
+    URI.join(url, URI.escape(path))
+  end
+end
+
 def scrape_person(url, name, group)
   noko = noko_for(url)
 
   box = noko.css('.article-holder')
   images = box.css('img/@src')
-  data = { 
+  data = {
     id: url.to_s[/ns_article-(.*?)-(\d+)/, 1],
     name: name.tidy,
     party: group.tidy,
@@ -47,7 +55,7 @@ def scrape_person(url, name, group)
     term: 2014,
     source: url.to_s,
   }
-  data[:image] = URI.join(url, URI.escape(data[:image])).to_s unless data[:image].to_s.empty?
+  data[:image] = valid_uri(url, data[:image]).to_s unless data[:image].to_s.empty?
   ScraperWiki.save_sqlite([:id, :term], data)
 end
 


### PR DESCRIPTION
As [this issue](https://github.com/everypolitician/everypolitician-data/issues/12584) states, we were applying encoding to the urls of the politicians no matter if they were already encoded or not, resulting in some image urls being encoded twice.

This PR fixes that by first unescaping and then escaping the url.
Closes https://github.com/everypolitician/everypolitician-data/issues/12584
