### PR TITLE
Scrape ceased members with links to member pages

### DIFF
--- a/lib/ceased_member_row.rb
+++ b/lib/ceased_member_row.rb
@@ -15,4 +15,8 @@ class CeasedMemberRow < Scraped::HTML
     # we always get the party name for each row
     noko.xpath('a/following-sibling::text()').first.text.tidy
   end
+
+  field :end_date do
+    Date.parse(noko.text[/\d{1,2}\.\d{1,2}\.\d{4}/, 0]).to_s
+  end
 end

--- a/lib/ceased_member_row.rb
+++ b/lib/ceased_member_row.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'scraped'
+
+class CeasedMemberRow < Scraped::HTML
+  field :source do
+    noko.css('a @href').text
+  end
+
+  field :name do
+    noko.css('a').text
+  end
+
+  field :party do
+    # The layout is inconsistent. Scraping this way
+    # we always get the party name for each row
+    noko.xpath('a/following-sibling::text()').first.text.tidy
+  end
+end

--- a/lib/ceased_members_page.rb
+++ b/lib/ceased_members_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require_relative 'sobranie_page'
+require_relative 'ceased_member_row'
+
+class CeasedMembersPage < SobraniePage
+  field :members do
+    noko.xpath('//div[@class="row"]/p[a]').map do |p|
+      fragment p => CeasedMemberRow
+    end
+  end
+end

--- a/lib/groups_page.rb
+++ b/lib/groups_page.rb
@@ -4,10 +4,22 @@ require_relative 'sobranie_page'
 class GroupsPage < SobraniePage
   decorator Scraped::Response::Decorator::AbsoluteUrls
 
+  CEASED_MEMBERS_URL = 'mps-whose-mandate-has-not-been-completed'
+
   field :groups do
-    # The rejected page is not a list of members grouped by party
-    noko.css('div.toc li a')
-        .reject { |a| a.attr('href') == 'http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx' }
-        .map { |a| fragment a => LinkLine }
+    groups_links.last.map { |a| fragment a => LinkLine }
+  end
+
+  field :ceased_members_url do
+    groups_links.first.first.attr('href')
+  end
+
+  private
+
+  # The layout of this page is to list all the groups, but at the end,
+  # in an otherwise undistinguished entry, there's a list to a separate
+  # page of all the ceased members.
+  def groups_links
+    noko.css('div.toc li a').partition { |a| a.attr('href').include? CEASED_MEMBERS_URL }
   end
 end

--- a/lib/groups_page.rb
+++ b/lib/groups_page.rb
@@ -5,8 +5,9 @@ class GroupsPage < SobraniePage
   decorator Scraped::Response::Decorator::AbsoluteUrls
 
   field :groups do
-    noko.css('div.toc li a').map do |a|
-      fragment a => LinkLine
-    end
+    # The rejected page is not a list of members grouped by party
+    noko.css('div.toc li a')
+        .reject { |a| a.attr('href') == 'http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx' }
+        .map { |a| fragment a => LinkLine }
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -21,11 +21,24 @@ end
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
 start = 'http://sobranie.mk/current-structure-2014-2018.nspx'
-data = scrape(start => GroupsPage).groups.flat_map do |group|
+groups = scrape(start => GroupsPage).groups
+# The structure of the last page differs from the others.
+# We will scrape it separately.
+party_groups = groups[0...-1]
+ceased_members_group = groups.last
+term = 2014
+
+current_members = party_groups.flat_map do |group|
+  puts group.source
   scrape(group.source => GroupPage).members.map do |mem|
-    mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: group.name, term: 2014))
+    mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: group.name, term: term))
   end
 end
-# puts data.map { |r| r.reject { |k, v| v.to_s.empty? }.sort_by { |k,v| k }.to_h }
 
+ceased_members = scrape(ceased_members_group.source => CeasedMembersPage).members.map do |mem|
+  mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: mem.party, term: term))
+end
+
+data = current_members + ceased_members
+# puts data.map { |r| r.reject { |k, v| v.to_s.empty? }.sort_by { |k,v| k }.to_h }
 ScraperWiki.save_sqlite(%i(id term), data)

--- a/scraper.rb
+++ b/scraper.rb
@@ -25,7 +25,6 @@ ceased_members_url = 'http://sobranie.mk/mps-whose-mandate-has-not-been-complete
 term = 2014
 
 current_members = scrape(start => GroupsPage).groups.flat_map do |group|
-  puts group.source
   scrape(group.source => GroupPage).members.map do |mem|
     mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: group.name, term: term))
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -21,21 +21,17 @@ end
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
 start = 'http://sobranie.mk/current-structure-2014-2018.nspx'
-groups = scrape(start => GroupsPage).groups
-# The structure of the last page differs from the others.
-# We will scrape it separately.
-party_groups = groups[0...-1]
-ceased_members_group = groups.last
+ceased_members_url = 'http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx'
 term = 2014
 
-current_members = party_groups.flat_map do |group|
+current_members = scrape(start => GroupsPage).groups.flat_map do |group|
   puts group.source
   scrape(group.source => GroupPage).members.map do |mem|
     mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: group.name, term: term))
   end
 end
 
-ceased_members = scrape(ceased_members_group.source => CeasedMembersPage).members.map do |mem|
+ceased_members = scrape(ceased_members_url => CeasedMembersPage).members.map do |mem|
   mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: mem.party, term: term))
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -21,16 +21,17 @@ end
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
 start = 'http://sobranie.mk/current-structure-2014-2018.nspx'
-ceased_members_url = 'http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx'
 term = 2014
 
-current_members = scrape(start => GroupsPage).groups.flat_map do |group|
+groups_page = scrape(start => GroupsPage)
+
+current_members = groups_page.groups.flat_map do |group|
   scrape(group.source => GroupPage).members.map do |mem|
     mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: group.name, term: term))
   end
 end
 
-ceased_members = scrape(ceased_members_url => CeasedMembersPage).members.map do |mem|
+ceased_members = scrape(groups_page.ceased_members_url => CeasedMembersPage).members.map do |mem|
   mem.to_h.merge(scrape(mem.source => MemberPage).to_h.merge(party: mem.party, term: term))
 end
 

--- a/test/cassettes/mps-whose-mandate-has-not-been-completed-2014-2018_nspx.yml
+++ b/test/cassettes/mps-whose-mandate-has-not-been-completed-2014-2018_nspx.yml
@@ -1,0 +1,483 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/html; charset=utf-8
+      Set-Cookie:
+      - ASP.NET_SessionId=ku4ayyeh42qrgo41mvjfbjah; path=/; HttpOnly
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Frame-Options:
+      - SAMEORIGIN
+      Date:
+      - Fri, 10 Feb 2017 13:18:27 GMT
+      Content-Length:
+      - '37534'
+    body:
+      encoding: UTF-8
+      string: "\r\n<!DOCTYPE html>\r\n<!--[if IE 8]>    <html class=\"no-js ie8\"
+        lang=\"en\"> <![endif]-->\r\n<!--[if IE 7]>    <html class=\"no-js ie7\" lang=\"en\">
+        <![endif]-->\r\n<!--[if gt IE 8]><!-->\r\n<html class=\"no-js gt-ie8\" lang=\"en\">\r\n<!--<![endif]-->\r\n<head><meta
+        charset=\"utf-8\" /><meta name=\"viewport\" content=\"width=device-width\"
+        /><meta property=\"og:image\" content=\"http://example.com/image.jpg\" /><link
+        rel=\"icon\" href=\"favicon.png\" type=\"image/x-icon\" />\r\n\r\n    <!--
+        JQ CSS -->\r\n    <link href=\"css/jquery-ui.css\" rel=\"stylesheet\" /><link
+        href=\"css/ui.jqgrid.css\" rel=\"stylesheet\" />\r\n\r\n    <!-- BOOTSTRAP
+        CSS -->\r\n\r\n    <link href=\"css/bootstrap.min.css\" rel=\"stylesheet\"
+        type=\"text/css\" media=\"screen\" /><link href=\"css/bootstrap-elements.css\"
+        rel=\"stylesheet\" type=\"text/css\" media=\"screen\" />\r\n\r\n\r\n    <!--
+        NEXTSENSE BASE CSS -->\r\n    <link href=\"css/ns-base.css\" rel=\"stylesheet\"
+        type=\"text/css\" media=\"screen\" /><link href=\"css/lightbox.css\" rel=\"stylesheet\"
+        type=\"text/css\" media=\"screen\" />\r\n\r\n    <!-- NEXTSENSE IMPLEMENTATION
+        SPECIFIC CSS -->\r\n\r\n    <link href=\"css/ns-implementation.css\" rel=\"stylesheet\"
+        type=\"text/css\" media=\"screen\" /><link href=\"css/ns-kalendar-naslovna.css?v=2\"
+        rel=\"stylesheet\" type=\"text/css\" media=\"screen\" /><link href=\"content/royal/royalslider.css\"
+        rel=\"stylesheet\" /><link href=\"content/royal/rs-universal.css\" rel=\"stylesheet\"
+        /><link href=\"css/hovernav.css\" rel=\"stylesheet\" />\r\n\r\n\r\n\r\n    <!--
+        IE8 SUPPORT JS -->\r\n    <!-- HTML5 shim and Respond.js IE8 support of HTML5
+        elements and media queries -->\r\n    <!--[if lt IE 9]>\r\n          <script
+        src=\"js/html5shiv.js\"></script>\r\n      \r\n          <script src=\"js/ie8-responsive-file-warning.js\"></script>\r\n
+        \       <![endif]-->\r\n\r\n    <!-- Enable responsive features in IE8 with
+        Respond.js (https://github.com/scottjehl/Respond) -->\r\n    <script src=\"js/respond.min.js\"></script>\r\n\r\n
+        \   <!-- JQUERY -->\r\n    <script src=\"js/jquery-1.10.2.min.js\"></script>\r\n
+        \   <!-- JQUERY 1.10.2 WEBMASTER FIX-->\r\n    <script src=\"js/jquery-migrate-1.2.1.min.js\"
+        type=\"text/javascript\"></script>\r\n\r\n\r\n\r\n    <script src=\"js/jquery-ui.min.js\"
+        type=\"text/javascript\"></script>\r\n\r\n    <script src=\"js/grid.locale-mk.js\"
+        type=\"text/javascript\"></script>\r\n    <script src=\"js/jquery.jqGrid.min.js\"
+        type=\"text/javascript\"></script>\r\n\r\n  <script src=\"js/jquery.blockUI.js\"
+        type=\"text/javascript\"></script>\r\n\r\n\r\n\r\n    <!-- BOOTSTRAP JS -->\r\n
+        \   <script src=\"js/bootstrap.min.js\"></script>\r\n    <script src=\"js/hovernav.js\"></script>\r\n\r\n
+        \   <script src=\"js/lightbox-2.6.min.js\"></script>\r\n\r\n    <link href=\"Content/bootstrap-elements.css\"
+        rel=\"stylesheet\" /><link href=\"Content/bootstrap.calendar.css\" rel=\"stylesheet\"
+        />\r\n    <script type=\"text/javascript\" src=\"js/MainScript.js\"></script>\r\n
+        \   \r\n    <script type=\"text/javascript\" src=\"js/bootstrap.calendar.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"js/jquery.json2.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"js/jquery.json-2.2.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"js/date.format.js\"></script>\r\n\r\n
+        \   <script>\r\n        function getUrlVars()\r\n        {\r\n            var
+        vars = [], hash;\r\n            var hashes = window.location.href.slice(window.location.href.indexOf('?')
+        + 1).split('&');\r\n            for(var i = 0; i < hashes.length; i++)\r\n
+        \           {\r\n                hash = hashes[i].split('=');\r\n                vars.push(hash[0]);\r\n
+        \               vars[hash[0]] = hash[1];\r\n            }\r\n            return
+        vars;\r\n        }\r\n    </script>\r\n\r\n    \r\n  \r\n    \r\n\r\n\r\n<script
+        type=\"text/javascript\">var pLang = 'EN';</script><title>\r\n\tMPs whose
+        mandate has not been completed 2014-2016\r\n</title></head>\r\n<body class=\"off-canvas
+        hide-extras\">\r\n    <form name=\"aspnetForm\" method=\"post\" action=\"/mps-whose-mandate-has-not-been-completed-2014-2018.nspx\"
+        autocomplete=\"off\" id=\"aspnetForm\">\r\n<div class=\"aspNetHidden\">\r\n<input
+        type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\" value=\"/wEPDwUENTM4MQ8WAh4TVmFsaWRhdGVSZXF1ZXN0TW9kZQIBZGT6Z/BL6egwsrVxYYPEQjqxqFY86dmpEBwK4bLZW/3doA==\"
+        />\r\n</div>\r\n\r\n        \r\n\r\n    <div class=\"container ns-z-index-2
+        ns-position-rel\">\r\n        <div class=\"row hidden-xs hidden-sm ns-header
+        ns-margin-bottom-m\">\r\n            <div class=\"col-lg-10 col-md-10\">\r\n
+        \               <div class=\"ns-header-left\">\r\n                    <a href=\"home-en.nspx\"
+        class=\"ns-header-logo ns-margin-top-s\"></a>\r\n                    <div
+        class=\"page-header ns-margin-left-m\">\r\n                        <h1 class=\"ns-margin-top-l
+        ns-margin-left-m\">Assembly\r\n                            <small>of the Republic
+        of Macedonia</small>\r\n                        </h1>\r\n                    </div>\r\n
+        \               </div>\r\n            </div>\r\n            <div class=\"col-lg-2
+        col-md-2\">\r\n                <div class=\" col-lg-12 col-md-12 ns-header-right\">\r\n
+        \                   <div class=\"ns-language-bar\">\r\n                        <a
+        href=\"pocetna.nspx\" class=\"ns-padding-top-l ns-padding-left-m ns-padding-right-m\">MK</a>\r\n
+        \                       <span class=\"ns-lang-bullet ns-padding-top-l\">|</span>\r\n
+        \                       <a href=\"home-al.nspx\" class=\"ns-padding-top-l
+        ns-padding-left-m ns-padding-right-m\">AL</a>\r\n                        \r\n
+        \                       <a href=\"home-en.nspx\" class=\"active ns-padding-top-l
+        ns-padding-left-m ns-padding-right-m ns-padding-bottom-s\">EN</a>\r\n                        \r\n
+        \                       <a href=\"home-fr.nspx\" class=\"last ns-padding-top-l
+        ns-padding-left-m ns-padding-left-m\">FR</a>\r\n                    </div>\r\n
+        \               </div>\r\n                <div class=\"col-lg-12 col-md-12\">\r\n\r\n\r\n
+        \                   <input type=\"text\" class=\"form-control ns-search-field\"
+        value=\"Search\" data-tooltip=\"Search\" data-url=\"search.nspx\" id=\"q\"
+        name=\"q\">\r\n                    <div class=\"ns-search-button\"><a class=\"search-now\"><span
+        class=\"glyphicon glyphicon-search\"></span></a></div>\r\n\r\n                </div>\r\n
+        \           </div>\r\n        </div>\r\n        <div class=\"row\">\r\n\r\n
+        \           <nav class=\"navbar navbar-default\" role=\"navigation\">\r\n
+        \               <div class=\"container-fluid ns-nav-inner\">\r\n                    <!--
+        Brand and toggle get grouped for better mobile display -->\r\n                    <div
+        class=\"navbar-header hidden-xs hidden-sm \">\r\n                        \r\n
+        \                       <button type=\"button\" class=\"navbar-toggle\" data-toggle=\"collapse\"
+        data-target=\".navbar-collapse\">\r\n                            <span class=\"sr-only\">Toggle
+        navigation</span>\r\n                            <span class=\"icon-bar\"></span>\r\n
+        \                           <span class=\"icon-bar\"></span>\r\n                            <span
+        class=\"icon-bar\"></span>\r\n                        </button>\r\n                        <a
+        class=\"navbar-brand ns-padding-left-s\" href=\"home-en.nspx\"><span class=\"glyphicon
+        glyphicon-home ns-padding-left-s\"></span>\r\n                            <p
+        class=\"hidden-xs \">Home</p>\r\n                        </a>\r\n                        \r\n
+        \                   </div>\r\n                    \r\n                    <div
+        class=\"navbar-header hidden-lg hidden-md\">\r\n                        <div
+        class=\"col-xs-3\">\r\n                        <a class=\"navbar-brand ns-padding-left-s\"
+        href=\"pocetna.nspx\"><span class=\"glyphicon glyphicon-home ns-padding-left-s\"></span>\r\n
+        \                           <p class=\"hidden-xs hidden-sm\">Home</p>\r\n
+        \                       </a>\r\n                            </div>\r\n                        \r\n
+        \                       <div class=\"col-xs-6 visible-xs search-m\">\r\n                                <input
+        type=\"text\" class=\"form-control ns-search-field\" value=\"Search\" data-tooltip=\"Search\"
+        data-url=\"search.nspx\" id=\"q\" name=\"q\">\r\n                                <div
+        class=\"ns-search-button ns-border-radius  \"><a class=\"search-now\"><span
+        class=\"glyphicon glyphicon-search\"></span></a></div>\r\n                            </div>\r\n
+        \                       <div class=\"col-xs-3\">\r\n                        <button
+        type=\"button\" class=\"navbar-toggle\" data-toggle=\"collapse\" data-target=\".navbar-collapse\">\r\n
+        \                           <span class=\"sr-only\">Toggle navigation</span>\r\n
+        \                           <span class=\"icon-bar\"></span>\r\n                            <span
+        class=\"icon-bar\"></span>\r\n                            <span class=\"icon-bar\"></span>\r\n
+        \                       </button>\r\n                            </div>\r\n
+        \                       \r\n                    </div>\r\n\r\n                    <!--
+        Collect the nav links, forms, and other content for toggling -->\r\n                    <div
+        class=\"collapse navbar-collapse\">\r\n\r\n\r\n                        <ul
+        class=\"nav navbar-nav\">\r\n                            \r\n                            <li
+        class=\"dropdown ns-horizontal-subs\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a
+        href=\"#\" class=\"dropdown-toggle ns-menu-l1-item1\" data-toggle=\"dropdown\">About
+        the Assembly<b class=\"caret\"></b></a><ul class=\"dropdown-menu ns-z-index-1\"><li
+        class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"competencies.nspx\"
+        target=\"_self\">Competencies</a></li><li class=\"col-lg-3 col-md-4 col-sm-6
+        col-lg-12\"><a href=\"legislative-procedure.nspx\" target=\"_self\">Legislative
+        Procedure</a></li><li class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"assembly-palace.nspx\"
+        target=\"_self\">Assembly Palace</a></li><li class=\"col-lg-3 col-md-4 col-sm-6
+        col-lg-12\"><a href=\"the-constitution-of-the-republic-of-macedonia.nspx\"
+        target=\"_self\">The Constitution of the Republic of Macedonia</a></li><li
+        class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"rules-procedures-of-the-assembly.nspx\"
+        target=\"_self\">Rules & Procedures of the Assembly</a></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"law-on-the-assembly-of-rm.nspx\" target=\"_self\">Law
+        on the assembly of RM</a></li><li class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a
+        href=\"virtual-tour.nspx\" target=\"_self\">Virtual Tour</a></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"photo-gallery.nspx\" target=\"_self\">Photo
+        Gallery</a></li></ul></li><li class=\"dropdown ns-horizontal-subs\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a
+        href=\"#\" class=\"dropdown-toggle ns-menu-l1-item2\" data-toggle=\"dropdown\">MEMBERS
+        OF PARLIAMENT<b class=\"caret\"></b></a><ul class=\"dropdown-menu ns-z-index-1\"><li
+        class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"president-of-the-assembly.nspx\"
+        target=\"_self\">President of the Assembly</a><ul class=\"dropdown-menu2\"><li><a
+        href=\"biography.nspx\" target=\"_self\">Biography</a></li><li><a href=\"responsibilities-obligations.nspx\"
+        target=\"_self\">Responsibilities & Obligations</a></li><li><a href=\"speeches-addresses.nspx\"
+        target=\"_self\">Speeches & Addresses</a></li><li><a href=\"activities.nspx\"
+        target=\"_self\">Activities</a></li><li><a href=\"department-of-the-cabinet-of-the-president.nspx\"
+        target=\"_self\">Department of The Cabinet of the President</a></li><li><a
+        href=\"former-presidents-of-the-assembly.nspx\" target=\"_self\">Former Presidents
+        of the Assembly</a></li><li><a href=\"photo-gallery-7c6146e0-2ed6-409c-aa01-0ef66b4a6c09.nspx\"
+        target=\"_self\">Photo gallery</a></li></ul></li><li class=\"col-lg-3 col-md-4
+        col-sm-6 col-lg-12\"><a href=\"vice-presidents-of-the-assembly.nspx\" target=\"_self\">Vice
+        Presidents of the Assembly</a><ul class=\"dropdown-menu2\"><li><a href=\"vice-presidents-of-the-assembly-b5f4efff-060b-4b1e-81e4-71a05f621f8b.nspx\"
+        target=\"_self\">Vice Presidents of the Assembly</a></li><li><a href=\"31c11fbe-a45e-42c6-b35b-dbd1994f22e3.nspx\"
+        target=\"_self\">Former vice presidents</a></li></ul></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"members-of-parliament.nspx\" target=\"_self\">Members
+        of Parliament</a><ul class=\"dropdown-menu2\"><li><a href=\"mp-s-2016-2020.nspx\"
+        target=\"_self\">MP's 2016-2020</a></li><li><a href=\"mp-s-2014-2018.nspx\"
+        target=\"_self\">MP's 2014-2016</a></li><li><a href=\"mp-s-2011-2014.nspx\"
+        target=\"_self\">MP's 2011-2014</a></li><li><a href=\"mp-s-2008-2011.nspx\"
+        target=\"_self\">MP's 2008-2011</a></li><li><a href=\"mp-s-2006-2008.nspx\"
+        target=\"_self\">MP's 2006-2008</a></li><li><a href=\"mp-s-2002-2006.nspx\"
+        target=\"_self\">MP's 2002-2006</a></li><li><a href=\"mp-s-1998-2002.nspx\"
+        target=\"_self\">MP's 1998-2002</a></li><li><a href=\"mp-s-1994-1998.nspx\"
+        target=\"_self\">MP's 1994-1998</a></li><li><a href=\"mp-s-1991-1994.nspx\"
+        target=\"_self\">MP's 1991-1994</a></li></ul></li><li class=\"col-lg-3 col-md-4
+        col-sm-6 col-lg-12\"><a href=\"working-bodies.nspx\" target=\"_self\">Working
+        Bodies</a><ul class=\"dropdown-menu2\"><li><a href=\"other-bodies-ac7eb077-f832-4c61-8eff-7c8a157ef8ae.nspx\"
+        target=\"_self\">Other Bodies</a></li><li><a href=\"working-bodies-2014-2018.nspx\"
+        target=\"_self\">Working Bodies 2014-2016</a></li><li><a href=\"working-bodies-2011-2014.nspx\"
+        target=\"_self\">Working Bodies 2011-2014</a></li><li><a href=\"working-bodies-2008-2011.nspx\"
+        target=\"_self\">Working Bodies 2008-2011</a></li><li><a href=\"working-bodies-2006-2008.nspx\"
+        target=\"_self\">Working Bodies 2006-2008</a></li><li><a href=\"working-bodies-2002-2006.nspx\"
+        target=\"_self\">Working Bodies 2002-2006</a></li><li><a href=\"working-bodies-1998-2002.nspx\"
+        target=\"_self\">Working Bodies 1998-2002</a></li></ul></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"councils.nspx\" target=\"_self\">Councils</a><ul
+        class=\"dropdown-menu2\"><li><a href=\"2014-2018-councils.nspx\" target=\"_self\">2014-2016</a></li><li><a
+        href=\"2011-2014-7135b8d3-da09-47f7-839e-e77c21bfb7ca.nspx\" target=\"_self\">2011-2014</a></li><li><a
+        href=\"2008-2011-c2c8064f-f7b8-4dbe-8654-b32812455565.nspx\" target=\"_self\">2008-2011</a></li></ul></li><li
+        class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"delegations.nspx\"
+        target=\"_self\">Delegations</a><ul class=\"dropdown-menu2\"><li><a href=\"delegations-2014-2018.nspx\"
+        target=\"_self\">2014-2016</a></li><li><a href=\"2011-2014-dc386329-eccd-45b2-acf9-9634e0ef00f8.nspx\"
+        target=\"_self\">2011-2014</a></li><li><a href=\"2008-2011-f96ce113-c20b-4a56-9907-f38fcec07caa.nspx\"
+        target=\"_self\">2008-2011</a></li><li><a href=\"2006-2008-6ffb86a1-ede2-42be-b5f3-f29fe1d615ce.nspx\"
+        target=\"_self\">2006-2008</a></li><li><a href=\"2002-2006-a070d27d-5424-4a5f-ab8a-080c7205b80e.nspx\"
+        target=\"_self\">2002-2006</a></li></ul></li><li class=\"col-lg-3 col-md-4
+        col-sm-6 col-lg-12\"><a href=\"parliamentary-groups-for-cooperation.nspx\"
+        target=\"_self\">Parliamentary Groups For Cooperation</a><ul class=\"dropdown-menu2\"><li><a
+        href=\"2014-2018-pg-en.nspx\" target=\"_self\">2014-2016 </a></li><li><a href=\"2011-2014-7a71ce40-85c5-42b7-ba5f-9d7a3fac5a9c.nspx\"
+        target=\"_self\">2011-2014</a></li><li><a href=\"2008-2011-56b3c25c-0453-4c82-8721-fbbcef3c1aa1.nspx\"
+        target=\"_self\">2008-2011</a></li><li><a href=\"2006-2008-dab71301-7277-4d56-bb66-54b9e85696c1.nspx\"
+        target=\"_self\">2006-2008</a></li><li><a href=\"2002-2006-bf129c3b-f72a-4271-86db-3e79d77c43dd.nspx\"
+        target=\"_self\">2002-2006</a></li></ul></li><li class=\"col-lg-3 col-md-4
+        col-sm-6 col-lg-12\"><a href=\"women-parliamentarians-club.nspx\" target=\"_self\">Women
+        Parliamentarians' Club</a><ul class=\"dropdown-menu2\"><li><a href=\"for-the-club.nspx\"
+        target=\"_self\">For The Club</a></li><li><a href=\"mission.nspx\" target=\"_self\">Mission</a></li><li><a
+        href=\"structure.nspx\" target=\"_self\">Structure</a></li><li><a href=\"presidency.nspx\"
+        target=\"_self\">Presidency</a></li><li><a href=\"activities-03816e6f-d281-477c-a11b-743b5024d092.nspx\"
+        target=\"_self\">Activities</a></li><li><a href=\"achievements.nspx\" target=\"_self\">Achievements</a></li><li><a
+        href=\"documents.nspx\" target=\"_self\">Documents</a></li><li><a href=\"gallery.nspx\"
+        target=\"_self\">Gallery</a></li><li><a href=\"contact.nspx\" target=\"_self\">Contact</a></li></ul></li></ul></li><li
+        class=\"dropdown ns-horizontal-subs\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a
+        href=\"#\" class=\"dropdown-toggle ns-menu-l1-item3\" data-toggle=\"dropdown\">Assembly
+        Staff<b class=\"caret\"></b></a><ul class=\"dropdown-menu ns-z-index-1\"><li
+        class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"secretary-general-of-the-assembly.nspx\"
+        target=\"_self\">Secretary General of the Assembly</a></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"deputy-secretary-generals.nspx\" target=\"_self\">Deputy
+        Secretary Generals </a></li><li class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a
+        href=\"former-secretaries-general.nspx\" target=\"_self\">Former Secretaries
+        General</a></li><li class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a href=\"organization.nspx\"
+        target=\"_self\">Organization</a></li></ul></li><li class=\"dropdown ns-horizontal-subs\"
+        xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a href=\"#\" class=\"dropdown-toggle
+        ns-menu-l1-item4\" data-toggle=\"dropdown\">International Cooperation<b class=\"caret\"></b></a><ul
+        class=\"dropdown-menu ns-z-index-1\"><li class=\"col-lg-3 col-md-4 col-sm-6
+        col-lg-12\"><a href=\"ecprd.nspx\" target=\"_self\">ECPRD</a></li><li class=\"col-lg-3
+        col-md-4 col-sm-6 col-lg-12\"><a href=\"ipex-e4ba5a44-0873-4a15-8599-c2ae9b2de00b.nspx\"
+        target=\"_self\">IPEX</a></li><li class=\"col-lg-3 col-md-4 col-sm-6 col-lg-12\"><a
+        href=\"seecp.nspx\" target=\"_self\">SEECP</a></li></ul></li>\r\n\r\n                        </ul>\r\n\r\n
+        \                   </div>\r\n                    <!-- /.navbar-collapse -->\r\n
+        \               </div>\r\n                <!-- /.container-fluid -->\r\n            </nav>\r\n\r\n
+        \       </div>\r\n    </div>\r\n\r\n\r\n\r\n    \r\n\r\n\r\n    <div class=\"container\">\r\n
+        \       <div class=\"row hidden-xs\">\r\n            <div class=\"ns-breadcrumbs
+        ns-padding-bottom-m ns-padding-top-l ns-padding-left-l\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a
+        href=\"home-en.nspx\" class=\"ns-margin-left-s ns-margin-right-s\" title=\"Home\">Home</a>
+        \ |\r\n            <a href=\"pratenicki-sostav-en.nspx\" class=\"ns-margin-left-s
+        ns-margin-right-s\" title=\"MEMBERS OF PARLIAMENT\">MEMBERS OF PARLIAMENT</a>
+        \ |\r\n            <a href=\"members-of-parliament.nspx\" class=\"ns-margin-left-s
+        ns-margin-right-s\" title=\"Members of Parliament\">Members of Parliament</a>
+        \ |\r\n            <a href=\"mp-s-2014-2018.nspx\" class=\"ns-margin-left-s
+        ns-margin-right-s\" title=\"MP's 2014-2016\">MP's 2014-2016</a>  |\r\n            <a
+        href=\"current-structure-2014-2018.nspx\" class=\"ns-margin-left-s ns-margin-right-s\"
+        title=\"Last structure 2014-2016\">Last structure 2014-2016</a>  |\r\n            <span
+        title=\"MPs whose mandate has not been completed 2014-2016\">MPs whose mandate
+        has not been completed 2014-2016</span></div>\r\n        </div>\r\n        <div
+        class=\" col-lg-12 col-md-12 col-sm-12 col-xs-12 ns-padding-15box hidden-lg
+        hidden-md\">\r\n            <div class=\"panel-group hidden-md hidden-lg pan-mb\"
+        id=\"accordion2\">\r\n                <div class=\"panel panel-default\">\r\n
+        \                   <div class=\"panel-heading left-nav\">\r\n                        <h4
+        class=\"panel-title\">\r\n                            <a data-toggle=\"collapse\"
+        data-parent=\"#accordion2\" href=\"#collapseTwo\">Menu\r\n                                    <b
+        class=\"caret29\"></b>\r\n                            </a>\r\n\r\n                        </h4>\r\n
+        \                   </div>\r\n                    <div id=\"collapseTwo\"
+        class=\"panel-collapse collapse\">\r\n                        <ul class=\"nav-sidebar2
+        ns-gradient-light\">\r\n                            <li>\r\n  <a href=\"president-of-the-assembly.nspx\">President
+        of the Assembly</a>\r\n</li>\r\n<li>\r\n  <a href=\"vice-presidents-of-the-assembly.nspx\">Vice
+        Presidents of the Assembly</a>\r\n</li>\r\n<li class=\"active\">\r\n  <a href=\"members-of-parliament.nspx\">Members
+        of Parliament</a>\r\n  <ul>\r\n    <li>\r\n      <a href=\"mp-s-2016-2020.nspx\">MP's
+        2016-2020</a>\r\n    </li>\r\n    <li class=\"active3\">\r\n      <a href=\"mp-s-2014-2018.nspx\">MP's
+        2014-2016</a>\r\n      <ul>\r\n        <li class=\"active2\">\r\n          <a
+        href=\"current-structure-2014-2018.nspx\">Last structure 2014-2016</a>\r\n
+        \       </li>\r\n        <li>\r\n          <a href=\"election-results-2014.nspx\">Election
+        Results 2014</a>\r\n        </li>\r\n        <li>\r\n          <a href=\"election-2014.nspx\">Election
+        2014</a>\r\n        </li>\r\n        <li>\r\n          <a href=\"statistics-2014.nspx\">Statistics
+        2014</a>\r\n        </li>\r\n      </ul>\r\n    </li>\r\n    <li>\r\n      <a
+        href=\"mp-s-2011-2014.nspx\">MP's 2011-2014</a>\r\n    </li>\r\n    <li>\r\n
+        \     <a href=\"mp-s-2008-2011.nspx\">MP's 2008-2011</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-2006-2008.nspx\">MP's 2006-2008</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-2002-2006.nspx\">MP's 2002-2006</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1998-2002.nspx\">MP's 1998-2002</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1994-1998.nspx\">MP's 1994-1998</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1991-1994.nspx\">MP's 1991-1994</a>\r\n    </li>\r\n
+        \ </ul>\r\n</li>\r\n<li>\r\n  <a href=\"working-bodies.nspx\">Working Bodies</a>\r\n</li>\r\n<li>\r\n
+        \ <a href=\"councils.nspx\">Councils</a>\r\n</li>\r\n<li>\r\n  <a href=\"delegations.nspx\">Delegations</a>\r\n</li>\r\n<li>\r\n
+        \ <a href=\"parliamentary-groups-for-cooperation.nspx\">Parliamentary Groups
+        For Cooperation</a>\r\n</li>\r\n<li>\r\n  <a href=\"women-parliamentarians-club.nspx\">Women
+        Parliamentarians' Club</a>\r\n</li>\r\n                        </ul>\r\n                    </div>\r\n
+        \               </div>\r\n            </div>\r\n        </div>\r\n        <div
+        class=\"row ns-margin-bottom-xl ns-category-main-area\">\r\n\r\n\r\n\r\n            <div
+        class=\"col-lg-9 col-md-9 col-sm-12 col-xs-12 ns-padding-15box\">\r\n\r\n\r\n\r\n\r\n
+        \               <div class=\"clear-fix\"></div>\r\n                <div class=\"ns-category-main-area-left
+        ns-margin-right-m ns-gradient-light ns-padding-xxl\">\r\n                    <div
+        class=\"row ns-breadcrumbs2-container ns-margin-bottom-l\">\r\n                        <img
+        title=\"Pratenichki sostav\" alt=\"Pratenichki sostav\" height=\"200\" width=\"640\"
+        src=\"content/images/header-pratenicki-sostav.jpg\" /><div class=\"clear-fix
+        clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n
+        \                       <div class=\"ns-breadcrumbs2\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><span
+        class=\"ns-gradient-light ns-padding-l\">MEMBERS OF PARLIAMENT</span></div>\r\n
+        \                   </div>\r\n                    <div class=\"row\">\r\n
+        \                       <h2>MPs whose mandate has not been completed 2014-2016</h2>\r\n<p><br
+        />1. Rufi Osmani&nbsp;NDR<br />Termination of the mandate on 3th Session held
+        on 26.5.2014&nbsp;</p>\r\n<p>2. Musa Xhaferi DUI<br />Termination of the mandate
+        on 5th Session held on 19.6.2014&nbsp;<br /><br />3. Nikola Gruevski VMRO-DPMNE<br
+        />Termination of the mandate on 5th Session held on 19.6.2014&nbsp;<br /><br
+        />4. Elizabeta Kancheska-Milevska VMRO-DPMNE<br />Termination of the mandate
+        on 5th Session held on 19.6.2014&nbsp;<br /><br />5. Dime Spasov VMRO-DPMNE<br
+        />Termination of the mandate on 5th Session held on 19.6.2014&nbsp;<br /><br
+        />6. Gordana Jankuloska VMRO-DPMNE<br />Termination of the mandate on 5th
+        Session held on 19.6.2014&nbsp;<br /><br />7. Nikola Todorov VMRO-DPMNE<br
+        />Termination of the mandate on 5th Session held on 19.6.2014&nbsp;<br /><br
+        />8. Zoran Stavreski VMRO-DPMNE<br />Termination of the mandate on 5th Session
+        held on 19.6.2014&nbsp;<br /><br />9. Nikola Poposki VMRO-DPMNE<br />Termination
+        of the mandate on 5th Session held on 19.6.2014&nbsp;</p>\r\n<p>10. Aspazija
+        Sofijanova&nbsp;VMRO-DPMNE<br />Termination of the mandate on 6th Session
+        held on 23.6.2014</p>\r\n<p>11.&nbsp;Skodrane Darlista DUI<br />Termination
+        of the mandate on 7th Session held on 2.7.2014</p>\r\n<p>12.&nbsp;<a href=\"http://www.sobranie.mk/current-structure-2014-2018-ns_article-romeo-trenov-2014-en.nspx\">Romeo
+        Trenov</a>&nbsp;VMRO-DPMNE<br />Termination of the mandate on 72th Session
+        held on 29.10.2015&nbsp;</p>\r\n<p><span>13.&nbsp;</span><a href=\"http://www.sobranie.mk/current-structure-2014-2018-ns_article-silvana-boneva-2014-eng.nspx\">Silvana
+        Boneva</a>&nbsp;VMRO-DPMNE<br /><span>Termination of the mandate on 83th Session
+        held on 16.12.2015</span></p>\r\n<p>14. <a href=\"vmro-dpmne-2014-ns_article-emil-dimitriev-2014-en.nspx\">Emil
+        Dimitriev</a>&nbsp;VMRO-DPMNE<br />Termination of the mandate on 88th Session
+        held on 18.1.2016</p><div class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n
+        \                   </div>\r\n                </div>\r\n            </div>\r\n
+        \           <div class=\"col-lg-3 col-md-3 col-sm-12 col-xs-12 ns-padding-15box
+        hidden-xs\">\r\n\r\n                <div class=\" col-lg-12 col-md-12 col-sm-12
+        col-xs-12 hidden-sm hidden-xs\">\r\n                    <div class=\"panel-group\"
+        id=\"accordion\">\r\n                        <div class=\"panel panel-default\">\r\n
+        \                           <div class=\"panel-heading left-nav\">\r\n                                <h4
+        class=\"panel-title\">\r\n                                    <a data-toggle=\"collapse\"
+        data-parent=\"#accordion\" href=\"#collapseOne\">Menu\r\n                                    <b
+        class=\"caret29\"></b>\r\n                                    </a>\r\n\r\n
+        \                               </h4>\r\n                            </div>\r\n
+        \                           <div id=\"collapseOne\" class=\"panel-collapse
+        collapse in\">\r\n                                <ul class=\"nav-sidebar2
+        ns-gradient-light\">\r\n                                    <li>\r\n  <a href=\"president-of-the-assembly.nspx\">President
+        of the Assembly</a>\r\n</li>\r\n<li>\r\n  <a href=\"vice-presidents-of-the-assembly.nspx\">Vice
+        Presidents of the Assembly</a>\r\n</li>\r\n<li class=\"active\">\r\n  <a href=\"members-of-parliament.nspx\">Members
+        of Parliament</a>\r\n  <ul>\r\n    <li>\r\n      <a href=\"mp-s-2016-2020.nspx\">MP's
+        2016-2020</a>\r\n    </li>\r\n    <li class=\"active3\">\r\n      <a href=\"mp-s-2014-2018.nspx\">MP's
+        2014-2016</a>\r\n      <ul>\r\n        <li class=\"active2\">\r\n          <a
+        href=\"current-structure-2014-2018.nspx\">Last structure 2014-2016</a>\r\n
+        \       </li>\r\n        <li>\r\n          <a href=\"election-results-2014.nspx\">Election
+        Results 2014</a>\r\n        </li>\r\n        <li>\r\n          <a href=\"election-2014.nspx\">Election
+        2014</a>\r\n        </li>\r\n        <li>\r\n          <a href=\"statistics-2014.nspx\">Statistics
+        2014</a>\r\n        </li>\r\n      </ul>\r\n    </li>\r\n    <li>\r\n      <a
+        href=\"mp-s-2011-2014.nspx\">MP's 2011-2014</a>\r\n    </li>\r\n    <li>\r\n
+        \     <a href=\"mp-s-2008-2011.nspx\">MP's 2008-2011</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-2006-2008.nspx\">MP's 2006-2008</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-2002-2006.nspx\">MP's 2002-2006</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1998-2002.nspx\">MP's 1998-2002</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1994-1998.nspx\">MP's 1994-1998</a>\r\n    </li>\r\n
+        \   <li>\r\n      <a href=\"mp-s-1991-1994.nspx\">MP's 1991-1994</a>\r\n    </li>\r\n
+        \ </ul>\r\n</li>\r\n<li>\r\n  <a href=\"working-bodies.nspx\">Working Bodies</a>\r\n</li>\r\n<li>\r\n
+        \ <a href=\"councils.nspx\">Councils</a>\r\n</li>\r\n<li>\r\n  <a href=\"delegations.nspx\">Delegations</a>\r\n</li>\r\n<li>\r\n
+        \ <a href=\"parliamentary-groups-for-cooperation.nspx\">Parliamentary Groups
+        For Cooperation</a>\r\n</li>\r\n<li>\r\n  <a href=\"women-parliamentarians-club.nspx\">Women
+        Parliamentarians' Club</a>\r\n</li>\r\n                                </ul>\r\n
+        \                           </div>\r\n                        </div>\r\n                    </div>\r\n
+        \               </div>\r\n\r\n                <div class=\" col-lg-12 col-md-12
+        col-sm-12 col-xs-12 \">\r\n                    \r\n                </div>\r\n\r\n
+        \               <div class=\" ns-agenda-kalendar-home ns-margin-bottom-l\">\r\n
+        \                   \r\n  <div class=\"row\">\r\n        <div class=\"span4\"
+        id=\"calendar\">\r\n\t\t\t<div class=\"kalendar-header\">\r\n\t\t\t\t<div
+        class=\"levo \">\r\n\t\t\t\t<img src=\"../images/levo.png\" />\r\n\t\t\t\t</div>\r\n\t\t\t\t<div
+        class=\"mesec\">\r\n\t\t\t\t</div>\r\n\t\t\t\t<div class=\"desno\">\r\n\t\t\t\t<img
+        src=\"../images/desno.png\" />\r\n\t\t\t\t</div>\r\n\t\t\t\t<div class=\"lista\">\r\n\t\t\t\t</div>\r\n\t\t\t\t<div
+        class=\"kalendarce\">\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t</div>\r\n
+        \   </div>\r\n\r\n<div id=\"sednica\" style=\"\">\r\n \r\n</div>\r\n<em><strong><span
+        style=\"color: #993300;\">&gt; <span style=\"text-decoration: underline;\">AGENDA</span></span></strong></em><div
+        class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div><div
+        id=\"div_32bd9131-8aba-4d60-927f-953c252f9ca8\"><p><span style=\"font-size:
+        xx-small;\">Tuesday, 16 September 2014, 11:00, \"Boris Trajkovski\" Hall&nbsp;</span></p>\r\n<p><strong><span
+        style=\"font-size: xx-small;\">15TH MEETING OF THE COMMITTEE ON FINANCING
+        AND BUDGET &nbsp;</span></strong></p></div><p class=\"more-link\"><a href=\"democratic-party-of-albanians-2014-ns_article-15th-meeting-of-the-committee-on-financing-and-budget.nspx\">more...</a></p><div
+        id=\"div_9eead6ed-8e41-466e-96c8-5fb69247c83a\"><p><span style=\"font-size:
+        xx-small;\">Tuesday, 16 September 2014, 11:00, Constitutional Hall</span></p>\r\n<p><span
+        style=\"font-size: xx-small;\"><strong>8th Meeting of the committee on political
+        system and interethnic relations&nbsp;</strong></span></p></div><p class=\"more-link\"><a
+        href=\"democratic-party-of-albanians-2014-ns_article-8th-meeting-of-the-committee-on-political-system-and-interethnic-relations.nspx\">more...</a></p><div
+        id=\"div_c6f68c6d-2f14-4ce5-b105-068c6a6c5a81\"><p><span style=\"font-size:
+        xx-small;\">Tuesday, 16 September 2014, 13:00 Hall 1&nbsp;</span></p>\r\n<p><strong><span
+        style=\"font-size: xx-small;\">15th session of the Assembly of the Republic
+        of Macedonia&nbsp;</span></strong></p>\r\n<p><span style=\"font-size: xx-small;\">1st
+        continuation &nbsp;</span></p></div><p class=\"more-link\"><a href=\"democratic-party-of-albanians-2014-ns_article-15th-session-of-the-assembly-i.nspx\">more...</a></p><div
+        id=\"div_836e5fe3-1f47-442a-bf1d-8d68cca72282\"><p><span style=\"font-size:
+        xx-small;\">Tuesday, 16 September 2014, 14:00, Hall 4</span></p>\r\n<p><strong><span
+        style=\"font-size: xx-small;\">18th Meeting of the legislative Committee &nbsp;</span></strong></p></div><p
+        class=\"more-link\"><a href=\"democratic-party-of-albanians-2014-ns_article-18th-meeting-of-the-legislative-committee.nspx\">more...</a></p>\r\n
+        \               </div>\r\n                <div class=\" col-lg-12 col-md-12
+        col-sm-12 col-xs-12 \">\r\n                    <div class=\"ns-video ns-margin-bottom-l\"
+        xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a href=\"internet-tv-channel.nspx\"><img
+        src=\"content/sobranie_zivo_ban-EN.jpg\" width=\"243\" height=\"171\" /></a></div><div
+        class=\"ns-video ns-margin-bottom-l\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\"><a
+        href=\"https://www.youtube.com/watch?v=efkqyD3mZJY&amp;feature=youtu.be&amp;a\">
+        </a>\r\n<p><a href=\"https://www.youtube.com/watch?v=efkqyD3mZJY&amp;feature=youtu.be&amp;a\"></a><a
+        href=\"https://www.youtube.com/watch?v=efkqyD3mZJY&amp;feature=youtu.be&amp;a\"><img
+        src=\"content/images/sobranie-gradba1.jpg\" width=\"238\" height=\"166\" /></a></p>\r\n<p
+        style=\"text-align: center;\"><a href=\"https://www.youtube.com/watch?v=efkqyD3mZJY&amp;feature=youtu.be&amp;a\"></a><span
+        style=\"font-size: small;\"><a href=\"https://www.youtube.com/watch?v=efkqyD3mZJY&amp;feature=youtu.be&amp;a\">CHRONOLOGY
+        OF THE GREAT RENEWAL</a></span></p></div><p><a href=\"parliamentary-institute.nspx\"><a
+        href=\"parliamentary-institute.nspx\"><img src=\"content/images/PI-baner-english.jpg\"
+        width=\"238\" height=\"166\" /></a></a></p><div class=\"clear-fix clearfix\"
+        xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div><a href=\"osce-pa-15th-autumn-meeting-skopje-republic-of-macedonia.nspx\"><img
+        height=\"106\" width=\"238\" src=\"content/images/OSCE-PA-Skopje logo.png\"
+        /></a><br /><div class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n\r\n
+        \               </div>\r\n                <div class=\"col-lg-12 col-md-12
+        col-sm-6 col-xs-12 ns-padding-r-2\">\r\n                    \r\n                </div>\r\n
+        \               <div class=\"col-lg-12 col-md-12 col-sm-6 col-xs-12\">\r\n
+        \                   \r\n                </div>\r\n                <div class=\"col-sm-12
+        col-xs-12 ns-social ns-margin-bottom-l\">\r\n                    <hr class=\"ns-margin-15box
+        \" />\r\n                    <h3>Follow us on:</h3>\r\n                    <div
+        class=\" col-lg-4 col-md-4 col-sm-4 col-xs-4\">\r\n                        <a
+        class=\" fb ns-margin-l\" href=\"https://www.facebook.com/#!/SobranieRM?fref=ts\"
+        target=\"_blank\" title=\"Facebook\"></a>\r\n                    </div>\r\n
+        \                   <div class=\" col-lg-4 col-md-4 col-sm-4 col-xs-4\">\r\n
+        \                       <a class=\"twitter ns-margin-l\" href=\"https://twitter.com/SobranieMK\"
+        target=\"_blank\" title=\"Twitter\"></a>\r\n                    </div>\r\n
+        \                   <div class=\" col-lg-4 col-md-4 col-sm-4 col-xs-4\">\r\n
+        \                       <a class=\"utube ns-margin-l\" href=\"http://www.youtube.com/channel/UCD5qpVe9-yNv4Xu4b3EuKFw\"
+        target=\"_blank\" title=\"YouTube\"></a>\r\n                    </div>\r\n
+        \               </div>\r\n                <div class=\"col-lg-12 col-md-12
+        col-sm-6 col-xs-12\">\r\n                    \r\n                </div>\r\n\r\n\r\n
+        \               <div class=\"col-lg-12 col-md-12 col-sm-6 col-xs-12\">\r\n
+        \                   \r\n                </div>\r\n                <div class=\"col-lg-12
+        col-md-12 col-sm-6 col-xs-12\">\r\n                    \r\n                </div>\r\n\r\n\r\n\r\n
+        \           </div>\r\n        </div>\r\n    </div>\r\n\r\n\r\n    <div class=\"row
+        hidden-xs hidden-sm ns-footer ns-margin-top-l ns-padding-top-m\">\r\n        <div
+        class=\"container\">\r\n            <a href=\"#top\" class=\"ns-top-button\"></a>\r\n
+        \           <div class=\"col-md-3\">\r\n\r\n                <div class=\"ns-footer-menu-iconless\">\r\n
+        \                   <h1>Contact</h1>\r\n<p>11 Oktomvri 10,<br />1000 Skopje,&nbsp;<br
+        />Republic of Macedonia</p>\r\n<ul>\r\n<li>\r\n<p>e-mail:</p>\r\n<a href=\"mailto:sobranie@sobranie.mk\">sobranie@sobranie.mk</a></li>\r\n</ul><div
+        class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n
+        \                   <a class=\"display-in\" href=\"sitemap.nspx\">\r\n                        <img
+        src=\"../images/sitemap.png\" />\r\n                        Sitemap</a>\r\n
+        \                   \r\n                </div>\r\n            </div>\r\n            <div
+        class=\"col-md-3\">\r\n                <div class=\"ns-footer-menu-icon1\">\r\n
+        \                   <h1>About the Assembly</h1>\r\n<ul>\r\n<li><a href=\"competencies.nspx\">Competencies</a></li>\r\n<li><a
+        href=\"legislative-procedure.nspx\">Legislative Procedure</a></li>\r\n<li><a
+        href=\"assembly-palace.nspx\">Assembly Palace</a></li>\r\n<li><a href=\"the-constitution-of-the-republic-of-macedonia.nspx\">The
+        Constitution of the RM</a></li>\r\n<li><a href=\"rules-procedures-of-the-assembly.nspx\">Rules
+        &amp; Procedures of the Assembly</a></li>\r\n<li><a href=\"law-on-the-assembly-of-rm.nspx\">Law
+        on the assembly of RM</a></li>\r\n<li><a href=\"virtual-tour-9158abe6-59f1-4eb6-87c7-8693f7e5a3a0.nspx\">Virtual
+        Tour</a></li>\r\n<li><a href=\"photo-gallery.nspx\">Photo Gallery</a></li>\r\n</ul><div
+        class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n\r\n
+        \               </div>\r\n            </div>\r\n            <div class=\"col-md-3\">\r\n
+        \               <div class=\"ns-footer-menu-icon2\">\r\n                    <h1>Members
+        of Parliament</h1>\r\n<ul>\r\n<li><a href=\"president-of-the-assembly.nspx\">President
+        of the Assembly</a></li>\r\n<li><a href=\"vice-presidents-of-the-assembly.nspx\">Vice
+        Presidents of the Assembly</a></li>\r\n<li><a href=\"members-of-parliament.nspx\">Members
+        of Parliament</a></li>\r\n<li><a href=\"working-bodies.nspx\">Working Bodies</a></li>\r\n<li><a
+        href=\"councils.nspx\">Councils</a></li>\r\n<li><a href=\"parliamentary-groups-for-cooperation.nspx\">Parliamentary
+        Groups For Cooperation</a></li>\r\n<li><a href=\"women-parliamentarians-club.nspx\">Women
+        Parliamentarians' Club</a></li>\r\n</ul><div class=\"clear-fix clearfix\"
+        xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n\r\n                </div>\r\n
+        \           </div>\r\n            <div class=\"col-md-3\">\r\n                <div
+        class=\"ns-footer-menu-icon3\">\r\n                    <h1>Assembly Staff</h1>\r\n<ul>\r\n<li><a
+        href=\"secretary-general-of-the-assembly.nspx\">Secretary General of the Assembly</a></li>\r\n<li><a
+        href=\"deputy-secretary-generals.nspx\">Deputy Secretary Generals</a></li>\r\n<li><a
+        href=\"organization.nspx\">Organization</a></li>\r\n<li><a href=\"former-secretaries-general.nspx\">Former
+        Secretary Generals</a></li>\r\n</ul><div class=\"clear-fix clearfix\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\">&nbsp;</div>\r\n\r\n
+        \               </div>\r\n            </div>\r\n        </div>\r\n    </div>\r\n
+        \   <div class=\"row hidden-xs hidden-sm ns-footer2 ns-padding-top-l ns-padding-bottom-m\">\r\n
+        \       <div class=\"container\">\r\n            <p class=\"text-center\">\r\n
+        \               Copyright 2014 <span class=\"glyphicon glyphicon-copyright-mark\"></span>Assembly
+        of the Republic of Macedonia | All rights reserved.\r\n            </p>\r\n
+        \       </div>\r\n    </div>\r\n    <script src=\"../content/royal/jquery.royalslider.min.js\"
+        ></script>\r\n<script>\r\n  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){\r\n
+        \ (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),\r\n
+        \ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)\r\n
+        \ })(window,document,'script','//www.google-analytics.com/analytics.js','ga');\r\n\r\n
+        \ ga('create', 'UA-8506694-1', 'auto');\r\n  ga('send', 'pageview');\r\n \r\n</script>\r\n\t\r\n
+        \   <script>\r\n        $(document).ready(function () {\r\n            $(\"#fb-like\").html(\"<iframe
+        scrolling='no' frameborder='0' allowtransparency='true' src='http://www.facebook.com/plugins/like.php?locale=en_US&amp;href=\"
+        + document.URL + \"&amp;layout=button_count&amp;share=true&amp;show_faces=false&amp;width=550&amp;action=like&amp;font&amp;colorscheme=light&amp;height=80'
+        style='border: none; overflow: hidden; width: 550px; height: 30px;'></iframe>\");\r\n
+        \       })\r\n    </script>\r\n\r\n\r\n\r\n\r\n                \r\n<div class=\"aspNetHidden\">\r\n\r\n\t<input
+        type=\"hidden\" name=\"__VIEWSTATEGENERATOR\" id=\"__VIEWSTATEGENERATOR\"
+        value=\"CA0B0334\" />\r\n</div></form>\r\n\r\n    <!-- NS JS -->\r\n    <script
+        src=\"js/ns.js?v=2\"></script>\r\n    <script src=\"js/Kalendar.js\"></script>\r\n</body>\r\n</html>\r\n"
+    http_version: 
+  recorded_at: Fri, 10 Feb 2017 13:21:51 GMT
+recorded_with: VCR 3.0.3

--- a/test/ceased_members_test.rb
+++ b/test/ceased_members_test.rb
@@ -13,9 +13,10 @@ describe 'ceased member' do
   describe 'Romeo Trenov' do
     it 'should have the expected data' do
       subject.first.to_h.must_equal(
-        source: 'http://www.sobranie.mk/current-structure-2014-2018-ns_article-romeo-trenov-2014-en.nspx',
-        name:   'Romeo Trenov',
-        party:  'VMRO-DPMNE'
+        source:   'http://www.sobranie.mk/current-structure-2014-2018-ns_article-romeo-trenov-2014-en.nspx',
+        name:     'Romeo Trenov',
+        party:    'VMRO-DPMNE',
+        end_date: '2015-10-29'
       )
     end
   end
@@ -24,9 +25,10 @@ describe 'ceased member' do
   describe 'Emil Dimitriev' do
     it 'should have the expected data' do
       subject.last.to_h.must_equal(
-        source: 'http://sobranie.mk/vmro-dpmne-2014-ns_article-emil-dimitriev-2014-en.nspx',
-        name:   'Emil Dimitriev',
-        party:  'VMRO-DPMNE'
+        source:   'http://sobranie.mk/vmro-dpmne-2014-ns_article-emil-dimitriev-2014-en.nspx',
+        name:     'Emil Dimitriev',
+        party:    'VMRO-DPMNE',
+        end_date: '2016-01-18'
       )
     end
   end

--- a/test/ceased_members_test.rb
+++ b/test/ceased_members_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require_relative '../lib/ceased_members_page.rb'
+
+describe 'ceased member' do
+  URL = 'http://sobranie.mk/mps-whose-mandate-has-not-been-completed-2014-2018.nspx'
+  around { |test| VCR.use_cassette(URL.split('/').last, &test) }
+  subject do
+    CeasedMembersPage.new(response: Scraped::Request.new(url: URL).response)
+                     .members
+  end
+
+  describe 'Romeo Trenov' do
+    it 'should have the expected data' do
+      subject.first.to_h.must_equal(
+        source: 'http://www.sobranie.mk/current-structure-2014-2018-ns_article-romeo-trenov-2014-en.nspx',
+        name:   'Romeo Trenov',
+        party:  'VMRO-DPMNE'
+      )
+    end
+  end
+
+  # Second test for a row with a slightly different layout
+  describe 'Emil Dimitriev' do
+    it 'should have the expected data' do
+      subject.last.to_h.must_equal(
+        source: 'http://sobranie.mk/vmro-dpmne-2014-ns_article-emil-dimitriev-2014-en.nspx',
+        name:   'Emil Dimitriev',
+        party:  'VMRO-DPMNE'
+      )
+    end
+  end
+end

--- a/test/ceased_members_test.rb
+++ b/test/ceased_members_test.rb
@@ -32,4 +32,16 @@ describe 'ceased member' do
       )
     end
   end
+
+  # Third test for a row where the party ID is in a different text node
+  describe 'Silvana Boneva' do
+    it 'should have the expected data' do
+      subject[1].to_h.must_equal(
+        source:   'http://www.sobranie.mk/current-structure-2014-2018-ns_article-silvana-boneva-2014-eng.nspx',
+        name:     'Silvana Boneva',
+        party:    'VMRO-DPMNE',
+        end_date: '2015-12-16'
+      )
+    end
+  end
 end


### PR DESCRIPTION
This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/issues/25491

This scrapes three members who are no longer part of the legislature and are now listed on a separate page which has a layout that is different from the party group listings pages. There are fourteen members listed on this page but only three of them have links to individual member pages. The layout of the page is quite complex but these three members are easier to capture than the others.

Since, the three members are going missing in the latest import PRs, it makes sense to deal with them in their own PR. (issue: https://github.com/everypolitician-scrapers/macedonia-sobranie/issues/8)